### PR TITLE
Issue18 Query Parameters

### DIFF
--- a/app/controllers/MessageController.js
+++ b/app/controllers/MessageController.js
@@ -36,31 +36,6 @@ MessageController.prototype.create = function () {
   return mongodb.ResourceController.prototype.create.call (this, opts);
 };
 
-MessageController.prototype.getAll = function () {
-  var opts = {
-    on: {
-      prepareOptions: function (req, callback) {
-        var token = req.headers.authorization.split(' ')[1];
-
-        User.findOne({token: token}, function (err, user) {
-          /* istanbul ignore if */
-          if (err) {
-            return callback(err);
-          }
-
-          if (!req.query.org_id) {
-            req.query.org_id = user.org_id;
-          }
-
-          return callback ();
-        });
-      }
-    }
-  };
-
-  return mongodb.ResourceController.prototype.getAll.call (this, opts);
-};
-
 blueprint.controller (MessageController, ResourceController);
 
 module.exports = MessageController;

--- a/app/controllers/MessageController.js
+++ b/app/controllers/MessageController.js
@@ -3,7 +3,6 @@
 var blueprint = require ('@onehilltech/blueprint')
   , mongodb = require ('@onehilltech/blueprint-mongodb')
   , ResourceController = mongodb.ResourceController
-  , async = require ('async')
   ;
 
 var Message = require ('../models/Message')
@@ -37,78 +36,26 @@ MessageController.prototype.create = function () {
   return mongodb.ResourceController.prototype.create.call (this, opts);
 };
 
-MessageController.prototype.getMessagesByOrg = function () {
-  return function (req, res) {
-    var token = req.headers.authorization.split(' ')[1];
+MessageController.prototype.getAll = function () {
+  var opts = {
+    on: {
+      prepareOptions: function (req, callback) {
+        var token = req.headers.authorization.split(' ')[1];
 
-    User.findOne({token: token}, function (err, user) {
-      /* istanbul ignore if */
-      if (err) {
-        res.status(400).json(err);
-        /* istanbul ignore if */
-      } else if (!user) {
-        res.status(404).send('User not found');
-      } else {
-        var org_id = user.org_id;
-        Message.find({org_id: org_id}, {__v: 0}, function (error, messages) {
+        User.findOne({token: token}, function (err, user) {
           /* istanbul ignore if */
-          if (error) {
-            res.status(400).json(error);
-          } else {
-            res.status(200).json(messages);
+          if (err) {
+            return callback(err);
           }
+
+          req.query.org_id = user.org_id;
+          return callback ();
         });
       }
-    });
-  }
-};
+    }
+  };
 
-MessageController.prototype.getMessagesBySender = function () {
-  return function (req, res) {
-    var token = req.headers.authorization.split(' ')[1];
-
-    async.waterfall ([
-        function (callback) {
-          User.findOne ({token: token}, callback)
-        },
-        function (user, callback) {
-          Message.find ({org_id: user.org_id, sender: user.username}, {__v: 0}, callback);
-        },
-        function (messages, callback) {
-          res.status (200).json ({messages: messages});
-          return callback (null);
-        }
-      ],
-      /* istanbul ignore next */
-      function (err) {
-        if (err) { res.status (400).send (err); }
-      });
-  }
-};
-
-MessageController.prototype.getMessagesByReceiver = function () {
-  return function(req, res){
-    // splits bearer and the token into an array ['bearer', token]
-    var token = req.headers.authorization.split(' ')[1];
-
-    async.waterfall([
-        function(callback){
-          User.findOne({token: token}, callback)
-        },
-        function (user, callback) {
-          Message.find({org_id: user.org_id, receiver: user.username}, {__v: 0}).exec(callback);
-        },
-        function (messages, callback) {
-          res.status(200).json({messages: messages});
-          return callback(null);
-        }
-      ],
-      /* istanbul ignore next */
-      function(err) {
-        if(err)
-          res.status(400).send(err);
-      });
-  }
+  return mongodb.ResourceController.prototype.getAll.call (this, opts);
 };
 
 blueprint.controller (MessageController, ResourceController);

--- a/app/controllers/MessageController.js
+++ b/app/controllers/MessageController.js
@@ -48,7 +48,10 @@ MessageController.prototype.getAll = function () {
             return callback(err);
           }
 
-          req.query.org_id = user.org_id;
+          if (!req.query.org_id) {
+            req.query.org_id = user.org_id;
+          }
+
           return callback ();
         });
       }

--- a/app/controllers/OrganizationController.js
+++ b/app/controllers/OrganizationController.js
@@ -1,7 +1,6 @@
 var blueprint = require ('@onehilltech/blueprint')
   , mongodb = require ('@onehilltech/blueprint-mongodb')
   , ResourceController = mongodb.ResourceController
-  , messaging = blueprint.messaging
   , async = require ('async')
   , nodemailer = require ('nodemailer')
   , nodeMailers = require ('../middleware/nodeMailers')

--- a/app/controllers/UserController.js
+++ b/app/controllers/UserController.js
@@ -12,32 +12,6 @@ function UserController () {
   ResourceController.call (this, {name: 'user', model: User});
 }
 
-UserController.prototype.getUsersByOrg = function () {
-  return function (req, res) {
-    var token = req.headers.authorization.split(' ')[1];
-
-    User.findOne({token: token}, function (err, user) {
-      /* istanbul ignore if */
-      if (err) {
-        res.status(400).json(err);
-      /* istanbul ignore if */
-      } else if (!user) {
-        res.status(404).send('User not found');
-      } else {
-        var org_id = user.org_id;
-        User.find({org_id:org_id}, {__v: 0, token: 0, password: 0}, function (error, users) {
-          /* istanbul ignore if */
-          if (error) {
-            res.status(400).json(error);
-          } else {
-            res.status(200).json(users);
-          }
-        });
-      }
-    });
-  }
-};
-
 UserController.prototype.create = function ()
 {
   var opts = {

--- a/app/routers/v1/MessageRouter.js
+++ b/app/routers/v1/MessageRouter.js
@@ -1,14 +1,6 @@
 // MessageRouter
 module.exports = exports = {
   '/messages' : {
-    '/sent': {
-      get: { action: 'MessageController@getMessagesBySender' }
-    },
-
-    '/received' : {
-      get: { action: 'MessageController@getMessagesByReceiver'}
-    },
-
     resource: {
       controller: 'MessageController',
       deny: ['delete']

--- a/app/routers/v1/OrganizationRouter.js
+++ b/app/routers/v1/OrganizationRouter.js
@@ -1,9 +1,6 @@
 // OrganizationRouter
 module.exports = exports = {
   '/organizations' : {
-    '/users': {
-      get: { action: 'UserController@getUsersByOrg' }
-    },
     resource: {
       controller: 'OrganizationController',
       deny: ['create', 'delete']

--- a/app/routers/v1/admin/OrganizationRouter.js
+++ b/app/routers/v1/admin/OrganizationRouter.js
@@ -1,9 +1,6 @@
 // OrganizationRouter
 module.exports = exports = {
   '/organizations' : {
-    '/messages': {
-      get: { action: 'MessageController@getMessagesByOrg' }
-    },
     resource: {
       controller: 'OrganizationController'
     }

--- a/tests/tests/unit-tests/routers/MessageRouterTest.js
+++ b/tests/tests/unit-tests/routers/MessageRouterTest.js
@@ -98,14 +98,14 @@ describe ('MessageRouter', function () {
 
       it ('should retrieve all messages by sender', function (done) {
         request (blueprint.app.server.app)
-        .get ('/v1/messages/sent')
+        .get ('/v1/messages?sender=' + newAdmin.username)
         .set ('Authorization', 'bearer ' + adminAccessToken)
         .expect (200, done);
       });
 
       it ('should retrieve messages to be received by user', function (done) {
         request (blueprint.app.server.app)
-        .get ('/v1/messages/received')
+        .get ('/v1/messages?receiver=' + newAdmin.username)
         .set('Authorization', 'bearer ' + adminAccessToken)
         .expect(200)
         .end(function (err, res) {
@@ -118,7 +118,7 @@ describe ('MessageRouter', function () {
 
       it ('should retrieve all messages by organization', function (done) {
         request (blueprint.app.server.app)
-        .get ('/v1/admin/organizations/messages')
+        .get ('/v1/messages?org_id=' + newAdmin.org_id)
         .set ('Authorization', 'bearer ' + adminAccessToken)
         .expect (200, done);
       });

--- a/tests/tests/unit-tests/routers/UserRouterTest.js
+++ b/tests/tests/unit-tests/routers/UserRouterTest.js
@@ -192,7 +192,7 @@ describe ('UserRouter', function () {
 
       it ('should get all users by organization', function (done) {
         request (blueprint.app.server.app)
-          .get ('/v1/organizations/users')
+          .get ('/v1/admin/users?org_id=' + org_id)
           .set ('Authorization', 'bearer ' + adminAccessToken)
           .expect (200, done);
       });


### PR DESCRIPTION
Updated Routers and Controller to use query parameters instead of additional routes.

/v1/messages/sent => /v1/messages?sender=username
/v1/messages/received => /v1/messages?receiver=username
/v1/organizations/users => /v1/users?org_id=org_id
/v1/admin/organization/messages => /v1/messages?org_id=org_id

This does bring up concerns on how to regulate query parameters.  For example, users should not be able to retrieve all messages for an entire organization.  I would like to discuss this further before merging.  Currently the 4th route is insecure due to this issue.